### PR TITLE
(SKP-208) [Server] 회원 탈퇴 시 알림 테이블의 데이터를 삭제한다

### DIFF
--- a/src/main/java/Skeep/backend/notification/domain/CategoryNotification/CategoryNotificationRepository.java
+++ b/src/main/java/Skeep/backend/notification/domain/CategoryNotification/CategoryNotificationRepository.java
@@ -2,12 +2,22 @@ package Skeep.backend.notification.domain.CategoryNotification;
 
 import Skeep.backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CategoryNotificationRepository extends JpaRepository<CategoryNotification, Long> {
+    // query method
     List<CategoryNotification> findAllByUser(User user);
     Optional<CategoryNotification> findByUserAndId(User user, Long id);
-    void deleteByUser(User user);
+
+    // @Query
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM CategoryNotification cn WHERE cn.user = :user")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/Skeep/backend/notification/domain/UserLocationNotification/UserLocationNotificationRepository.java
+++ b/src/main/java/Skeep/backend/notification/domain/UserLocationNotification/UserLocationNotificationRepository.java
@@ -2,12 +2,22 @@ package Skeep.backend.notification.domain.UserLocationNotification;
 
 import Skeep.backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UserLocationNotificationRepository extends JpaRepository<UserLocationNotification, Long> {
+    // query method
     List<UserLocationNotification> findAllByUser(User user);
     Optional<UserLocationNotification> findByUserAndId(User user, Long id);
-    void deleteByUser(User user);
+
+    // @Query
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM UserLocationNotification uln WHERE uln.user = :user")
+    void deleteByUser(@Param("user") User user);
 }


### PR DESCRIPTION
## 📌 Summary 
회원 탈퇴 시 알림 테이블의 데이터를 삭제한다

## 📝 Describe your changes 
- CategoryNotificationRepository, UserLocationNotificationRepository에 @Modifying 어노테이션을 추가

## ✅ Check list 
- [X] I write PR according to the form
- [ ] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## 🚪 Issue numbers and link 
Closes #186 